### PR TITLE
Change requires to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     url = 'https://pypi.python.org/pypi/%s/%s' % (pkgname, cpl_version),
     download_url = '%s/%s-%s.tar.gz' % (baseurl, pkgname, cpl_version),
     classifiers = classifiers,
-    requires = [ required ],
+    install_requires = [ required ],
     provides = ['cpl'],
     packages = ['cpl'],
     ext_modules = [module1]


### PR DESCRIPTION
The former has been deprecated in favor of the latter...came across this in adding `python-cpl` to the automated builder of conda packages for affiliated packages.