### PR TITLE
Remove pyfits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 
 python:
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
+    - 3.6
 
 addons:
   apt:
@@ -14,8 +14,7 @@ addons:
 
 install:
     - pip install coveralls
-    - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install astropy==1.0.10; else pip install astropy; fi
-    - python setup.py install
+    - pip install .
 
 script: (cd test && coverage run --source=cpl TestRecipe.py && mv -f .coverage ..)
 

--- a/cpl/dfs.py
+++ b/cpl/dfs.py
@@ -1,8 +1,5 @@
 import sys
-try: # pragma: no cover
-    from astropy.io import fits
-except ImportError:
-    import pyfits as fits
+from astropy.io import fits
 
 import cpl
 

--- a/cpl/frames.py
+++ b/cpl/frames.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 import os
-try: # pragma: no cover
-    from astropy.io import fits
-except ImportError:
-    import pyfits as fits
+from astropy.io import fits
 
 from . import md5sum
 

--- a/cpl/recipe.py
+++ b/cpl/recipe.py
@@ -7,10 +7,7 @@ import collections
 import warnings
 import textwrap
 
-try: # pragma: no cover
-    from astropy.io import fits
-except ImportError:
-    import pyfits as fits
+from astropy.io import fits
 
 from . import CPL_recipe
 from .frames import FrameList, mkabspath, expandframelist

--- a/cpl/result.py
+++ b/cpl/result.py
@@ -3,10 +3,7 @@ import os
 import signal
 import logging
 
-try: # pragma: no cover
-    from astropy.io import fits
-except ImportError:
-    import pyfits as fits
+from astropy.io import fits
 
 class Result(object):
     def __init__(self, directory, res, input_len = 0, logger = None, 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -5,8 +5,7 @@ Prequisites
 -----------
 
 * `Python <http://www.python.org/>`_ 2.6 or higher, 
-* `Astropy <http://www.astropy.org/>`_ or 
-  `Pyfits <http://packages.python.org/pyfits/>`_
+* `Astropy <http://www.astropy.org/>`_
 
 Binary packages
 ---------------

--- a/oca/organizer.py
+++ b/oca/organizer.py
@@ -3,7 +3,7 @@ from optparse import OptionParser
 import fnmatch
 
 import numpy
-import pyfits
+from astropy.io import fits
 
 class Constant(object):
     def __init__(self, value):
@@ -238,7 +238,7 @@ if __name__ == "__main__":
 
     files = list()
     for f in filenames:
-        hdulist = pyfits.open(f)
+        hdulist = fits.open(f)
         var = dict(hdulist[0].header)
         var.setdefault('FILENAME', f)
         organizer.classify(var)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 from distutils.core import setup, Extension
-from pkg_resources import require, DistributionNotFound
 
 author = 'Ole Streicher'
 email = 'python-cpl@liska.ath.cx'
@@ -50,11 +49,6 @@ except IOError:
 
 module1 = Extension('cpl.CPL_recipe',
                     sources = ['cpl/CPL_recipe.c', 'cpl/CPL_library.c'])
-try:
-    require('astropy')
-    required='astropy'
-except DistributionNotFound:
-    required = 'pyfits'
 
 setup(
     name = pkgname,
@@ -67,7 +61,7 @@ setup(
     url = 'https://pypi.python.org/pypi/%s/%s' % (pkgname, cpl_version),
     download_url = '%s/%s-%s.tar.gz' % (baseurl, pkgname, cpl_version),
     classifiers = classifiers,
-    install_requires = [ required ],
+    install_requires = [ 'astropy' ],
     provides = ['cpl'],
     packages = ['cpl'],
     ext_modules = [module1]

--- a/test/TestRecipe.py
+++ b/test/TestRecipe.py
@@ -5,10 +5,7 @@ import tempfile
 import unittest
 
 import numpy
-try:
-    from astropy.io import fits
-except:
-    import pyfits as fits
+from astropy.io import fits
 import cpl
 cpl.Recipe.memory_mode = 0
 


### PR DESCRIPTION
Hi Ole,

This is to remove the Pyfits dependency from python-cpl, because:

- PyFITS is deprecated and no longer supported: https://github.com/spacetelescope/pyfits
- I'm having trouble with installing python-cpl in a fresh virtualenv (with tox), which requires Pyfits as Astropy is not yet installed in the virtualenv, and Pyfits installation crashes on Python 3.6... 