### PR TITLE
Update packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 *~
 *.pyc
+*.so
 #*
 *#
 .#*
+*.egg-info
 _build
 _static
 _templates

--- a/README.rst
+++ b/README.rst
@@ -6,10 +6,7 @@ python-cpl
 .. image:: https://img.shields.io/pypi/v/python-cpl.svg
     :target: https://pypi.python.org/pypi/python-cpl
 
-.. image:: https://img.shields.io/pypi/dm/python-cpl.svg
-    :target: https://pypi.python.org/pypi/python-cpl
-
-Python-cpl is an `Astropy Affiliated Package <http://www.astropy.org/affiliated/>`_ 
+Python-cpl is an `Astropy Affiliated Package <http://www.astropy.org/affiliated/>`_
 that can list, configure and execute recipes from `ESO data reduction
 pipelines <http://www.eso.org/sci/software/pipelines/>`_ from Python
 (python2 and python3).  The input, calibration and output data can be
@@ -27,7 +24,7 @@ Python-CPL releases are `registered on PyPI
 <http://pypi.python.org/pypi/python-cpl>`_, and development is occurring at
 the `project's github page <http://github.com/olebole/python-cpl>`_.
 
-For installation instructions, see the 
+For installation instructions, see the
 `online documentation <http://python-cpl.readthedocs.org/en/latest/install.html>`_.
 The travis test status, coverage, and documentation build status
 of the github repository is:
@@ -40,7 +37,7 @@ of the github repository is:
 
 .. image:: https://landscape.io/github/olebole/python-cpl/master/landscape.svg?style=flat
    :target: https://landscape.io/github/olebole/python-cpl/master
-	   
+
 .. image:: https://readthedocs.org/projects/python-cpl/badge/?version=latest
     :target: https://readthedocs.org/projects/python-cpl/?badge=latest
 

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
 import os
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 author = 'Ole Streicher'
 email = 'python-cpl@liska.ath.cx'
 license_ = 'GPL'
 cpl_version = '0.7.2'
 description = "Python interface for the ESO Common Pipeline Library"
-long_description = '''This module can list, configure and execute CPL-based recipes from Python
+long_description = '''\
+This module can list, configure and execute CPL-based recipes from Python
 (python2 and python3).  The input, calibration and output data can be
 specified as FITS files or as ``astropy.io.fits`` objects in memory.
 
@@ -20,7 +21,8 @@ aspects of the CPL data-reduction development environment.
 '''
 
 pkgname = 'python-cpl'
-baseurl = 'http://pypi.python.org/packages/source/%s/%s' % (pkgname[0], pkgname)
+baseurl = ('https://files.pythonhosted.org/packages/source/'
+           '{0}/{1}/{1}-{2}.tar.gz'.format(pkgname[0], pkgname, cpl_version))
 classifiers = '''Development Status :: 4 - Beta
 Intended Audience :: Science/Research
 License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)
@@ -35,12 +37,13 @@ Topic :: Scientific/Engineering :: Astronomy
 '''.splitlines()
 
 
-def create_version_file(cpl_version = cpl_version):
+def create_version_file(cpl_version=cpl_version):
     with open(os.path.join('cpl', 'version.py'), 'w') as vfile:
         vfile.write("version = %s\n" % repr(cpl_version))
         vfile.write("author = %s\n" % repr(author))
         vfile.write("email = %s\n" % repr(email))
         vfile.write("license_ = %s\n" % repr(license_))
+
 
 try:
     create_version_file()
@@ -48,21 +51,21 @@ except IOError:
     pass
 
 module1 = Extension('cpl.CPL_recipe',
-                    sources = ['cpl/CPL_recipe.c', 'cpl/CPL_library.c'])
+                    sources=['cpl/CPL_recipe.c', 'cpl/CPL_library.c'])
 
 setup(
-    name = pkgname,
-    version = cpl_version,
-    author = author,
-    author_email = email,
-    description = description,
-    long_description = long_description,
-    license = license_,
-    url = 'https://pypi.python.org/pypi/%s/%s' % (pkgname, cpl_version),
-    download_url = '%s/%s-%s.tar.gz' % (baseurl, pkgname, cpl_version),
-    classifiers = classifiers,
-    install_requires = [ 'astropy' ],
-    provides = ['cpl'],
-    packages = ['cpl'],
-    ext_modules = [module1]
-    )
+    name=pkgname,
+    version=cpl_version,
+    author=author,
+    author_email=email,
+    description=description,
+    long_description=long_description,
+    license=license_,
+    url='https://pypi.org/project/%s/%s' % (pkgname, cpl_version),
+    download_url='%s/%s-%s.tar.gz' % (baseurl, pkgname, cpl_version),
+    classifiers=classifiers,
+    install_requires=['astropy'],
+    provides=['cpl'],
+    packages=['cpl'],
+    ext_modules=[module1]
+)

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
     url='https://pypi.org/project/%s/%s' % (pkgname, cpl_version),
     download_url='%s/%s-%s.tar.gz' % (baseurl, pkgname, cpl_version),
     classifiers=classifiers,
+    python_requires='>=2.7',
     install_requires=['astropy'],
     provides=['cpl'],
     packages=['cpl'],


### PR DESCRIPTION
- Update urls
- Add python_requires
- Switch to setuptools which is needed to get the correct metadata (and upload must be done with twine)
- Remove download count badge as this information is no more available