### PR TITLE
Verbose error message when cpl_dfs_update_product_header() fails

### DIFF
--- a/cpl/CPL_recipe.c
+++ b/cpl/CPL_recipe.c
@@ -852,7 +852,13 @@ CPL_recipe_exec(CPL_recipe *self, PyObject *args) {
 	    retval = self->cpl->plugin_get_exec(self->plugin)(self->plugin);
 	    int reto = self->cpl->dfs_update_product_header(recipe->frames);
 	    if (reto != CPL_ERROR_NONE) {
-		self->cpl->msg_error (__func__, "could not update the product header");
+		self->cpl->msg_error (__func__,
+				      "could not update the product header."
+				      " %s (%s:%s:%u)",
+				      self->cpl->error_get_message(),
+				      self->cpl->error_get_function(),
+				      self->cpl->error_get_file(),
+				      self->cpl->error_get_line());
 	    }
 	    times(&clock_end);
 	    clock_end.tms_utime -= clock_start.tms_utime;


### PR DESCRIPTION
This should fix #19 or at least improve the error message a bit.
@saimn could try this out? I don't had the experience of a failing `dfs_update_header()` so far.
