### PR TITLE
Use cpl_dfs_sign_products() instead of cpl_dfs_update_product_header()

### DIFF
--- a/cpl/CPL_library.c
+++ b/cpl/CPL_library.c
@@ -109,6 +109,11 @@ cpl_library_t *create_library(const char *fname) {
     cpl->pluginlist_new = dlsym(handle, "cpl_pluginlist_new");
 
     cpl->dfs_update_product_header = dlsym(handle, "cpl_dfs_update_product_header");
+    if (cpl->version >= CPL_VERSION(6,5,0)) {
+        cpl->dfs_sign_products = dlsym(handle, "cpl_dfs_sign_products");
+    } else {
+        cpl->dfs_sign_products = NULL;
+    }
 
     cpl->error_get_code = dlsym(handle, "cpl_error_get_code");
     cpl->error_get_file = dlsym(handle, "cpl_error_get_file");

--- a/cpl/CPL_library.h
+++ b/cpl/CPL_library.h
@@ -54,6 +54,7 @@ typedef struct {
     typeof(cpl_pluginlist_new) *pluginlist_new;
 
     typeof(cpl_dfs_update_product_header) *dfs_update_product_header;
+    typeof(cpl_dfs_sign_products) *dfs_sign_products;
 
     typeof(cpl_error_get_code) *error_get_code;
     typeof(cpl_error_get_file) *error_get_file;

--- a/cpl/CPL_recipe.c
+++ b/cpl/CPL_recipe.c
@@ -850,7 +850,14 @@ CPL_recipe_exec(CPL_recipe *self, PyObject *args) {
 	    times(&clock_start);
 	    setup_tracing(self, memory_trace);
 	    retval = self->cpl->plugin_get_exec(self->plugin)(self->plugin);
-	    int reto = self->cpl->dfs_update_product_header(recipe->frames);
+	    int reto;
+	    if (self->cpl->dfs_sign_products != NULL) {
+	        reto = self->cpl->dfs_sign_products(recipe->frames,
+						    CPL_DFS_SIGNATURE_DATAMD5 |
+						    CPL_DFS_SIGNATURE_CHECKSUM);
+	    } else {
+	        reto = self->cpl->dfs_update_product_header(recipe->frames);
+	    }
 	    if (reto != CPL_ERROR_NONE) {
 		self->cpl->msg_error (__func__,
 				      "could not update the product header."

--- a/cpl/cpl_api.h
+++ b/cpl/cpl_api.h
@@ -95,6 +95,7 @@ cpl_plugin *cpl_pluginlist_get_first(cpl_pluginlist *);
 cpl_plugin *cpl_pluginlist_get_next(cpl_pluginlist *);
 cpl_pluginlist *cpl_pluginlist_new(void);
 cpl_error_code cpl_dfs_update_product_header(cpl_frameset *);
+cpl_error_code cpl_dfs_sign_products(const cpl_frameset *, unsigned int);
 
 void cpl_msg_error(const char *, const char *, ...);
 cpl_error_code cpl_error_get_code(void);
@@ -192,5 +193,7 @@ const char *cpl_version_get_version(void);
 #define CPL_TYPE_DOUBLE (1 << 17)
 #define CPL_TYPE_INT (1 << 10)
 #define CPL_TYPE_STRING ((1 << 5)|(1 << 0))
+#define CPL_DFS_SIGNATURE_DATAMD5  (1 << 0)
+#define CPL_DFS_SIGNATURE_CHECKSUM  (1 << 1)
 
 #endif /* CPL_API_H */


### PR DESCRIPTION
This reflects a change in esorex 3.11. It seems that the `cpl_dfs_update_product_header()` function now behaves a bit differently and may return an erro (see #19).

To keep backward compatibility, we still use the old function if `cpl_dfs_sign_products()` is not available (before CPL version 6.5).

I hope that this fixes #19. @saimn could you be so kind and test this?